### PR TITLE
Use sample data in layouts

### DIFF
--- a/app/sampledata/sessions.json
+++ b/app/sampledata/sessions.json
@@ -1,0 +1,28 @@
+{
+  "data": [
+    {
+      "title": "Android Development",
+      "room": "Odin",
+      "starResource": "@drawable/star_filled",
+      "tag": "Android",
+      "company": "Google",
+      "time": "Thu, November 1 / 09:00"
+    },
+    {
+      "title": "Swift 102",
+      "room": "Freyja",
+      "starResource": "@drawable/star_filled",
+      "tag": "iOS",
+      "company": "Apple",
+      "time": "Thu, November 1 / 11:00"
+    },
+    {
+      "title": "React Native: The Good, The Bad and The Ugly",
+      "room": "Thor",
+      "starResource": "@drawable/star_empty",
+      "tag": "Mobile Web",
+      "company": "Facebook",
+      "time": "Thu, November 2 / 13:00"
+    }
+  ]
+}

--- a/app/src/main/res/layout/fragment_schedule.xml
+++ b/app/src/main/res/layout/fragment_schedule.xml
@@ -34,6 +34,7 @@
         android:indeterminateTint="@color/colorPrimary"
         app:layout_constraintTop_toTopOf="parent"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content" />
+        android:layout_height="wrap_content"
+        tools:visibility="gone" />
 
 </android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_session.xml
+++ b/app/src/main/res/layout/fragment_session.xml
@@ -18,7 +18,8 @@
             android:textColor="@color/colorPrimaryText"
             android:fontFamily="sans-serif-medium"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
+            android:layout_height="wrap_content"
+            tools:text="Android Development" />
 
         <TextView
             android:id="@+id/subtitleTextView"
@@ -28,15 +29,18 @@
             android:layout_marginStart="24dp"
             android:layout_marginEnd="24dp"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
+            android:layout_height="wrap_content"
+            tools:text="@sample/sessions.json/data/time" />
 
         <android.support.v7.widget.RecyclerView
             android:id="@+id/tagsRecyclerView"
             android:layout_marginTop="24dp"
             android:layout_marginStart="24dp"
             android:layout_marginEnd="24dp"
+            tools:itemCount="1"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"/>
+            android:layout_height="wrap_content"
+            tools:listitem="@layout/row_tag_clickable" />
 
         <TextView
             android:id="@+id/sessionTextView"
@@ -47,7 +51,8 @@
             android:textSize="18sp"
             android:lineSpacingExtra="4dp"
             android:layout_width="match_parent"
-            android:layout_height="match_parent" />
+            android:layout_height="match_parent"
+            tools:text="@tools:sample/lorem[25]" />
 
         <include
             android:id="@+id/speaker1Layout"
@@ -60,7 +65,8 @@
             android:id="@+id/speaker2Layout"
             layout="@layout/row_speaker"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
+            android:layout_height="wrap_content"
+            tools:visibility="gone" />
     </LinearLayout>
 
 </ScrollView>

--- a/app/src/main/res/layout/fragment_speakers.xml
+++ b/app/src/main/res/layout/fragment_speakers.xml
@@ -19,5 +19,6 @@
         android:indeterminateTint="@color/colorPrimary"
         app:layout_constraintTop_toTopOf="parent"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content" />
+        android:layout_height="wrap_content"
+        tools:visibility="gone" />
 </FrameLayout>

--- a/app/src/main/res/layout/row_header_timeslot.xml
+++ b/app/src/main/res/layout/row_header_timeslot.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <TextView
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/timeTextView"
     android:layout_width="wrap_content"
     android:gravity="center_vertical"
@@ -9,4 +10,5 @@
     android:textStyle="bold"
     android:layout_marginStart="112dp"
     android:textColor="@color/colorSecondaryText"
-    android:textAppearance="?attr/textAppearanceListItem" />
+    android:textAppearance="?attr/textAppearanceListItem"
+    tools:text="09:00 – 10:00" />

--- a/app/src/main/res/layout/row_session.xml
+++ b/app/src/main/res/layout/row_session.xml
@@ -32,12 +32,10 @@
             android:visibility="gone"
             android:layout_width="16dp"
             android:layout_height="16dp"
-
             android:textColor="@android:color/white"
             android:gravity="center"
             android:textSize="10sp"
             android:background="@drawable/background_rounded_dark"
-
             app:layout_constraintBottom_toBottomOf="@+id/avatarImageView"
             app:layout_constraintEnd_toEndOf="@+id/avatarImageView"
             tools:ignore="SmallSp" />
@@ -46,7 +44,6 @@
             android:id="@+id/titleTextView"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-
             android:textColor="@color/colorPrimaryText"
             android:textSize="20sp"
             android:maxLines="5"
@@ -54,21 +51,18 @@
             android:ellipsize="end"
             android:fontFamily="sans-serif-light"
             android:textAppearance="?attr/textAppearanceListItem"
-
             android:layout_marginStart="16dp"
             android:layout_marginEnd="48dp"
             app:layout_constraintStart_toEndOf="@+id/avatarImageView"
             app:layout_constraintTop_toTopOf="@+id/avatarImageView"
             app:layout_constraintEnd_toEndOf="parent"
-
-            />
+            tools:text="@sample/sessions.json/data/title" />
 
         <LinearLayout
             android:id="@+id/speakersInfoLinearLayout"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:orientation="horizontal"
-
             android:layout_marginStart="16dp"
             android:layout_marginTop="8dp"
             android:textAppearance="?attr/textAppearanceListItem"
@@ -79,17 +73,16 @@
                 android:id="@+id/nameTextView"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-
                 android:textColor="@color/colorPrimaryText"
                 android:textSize="12sp"
-                android:textStyle="bold" />
+                android:textStyle="bold"
+                tools:text="@tools:sample/full_names" />
 
             <View
                 android:id="@+id/separatorNameRoomView"
                 android:layout_width="1dp"
                 android:layout_height="12dp"
                 android:background="@color/colorSecondaryText"
-
                 android:layout_marginStart="4dp"
                 android:layout_gravity="center_vertical" />
 
@@ -100,7 +93,8 @@
                 android:layout_marginStart="4dp"
                 android:textColor="@color/colorSecondaryText"
                 android:textSize="12sp"
-                android:ellipsize="end" />
+                android:ellipsize="end"
+                tools:text="@sample/sessions.json/data/room" />
 
         </LinearLayout>
 
@@ -114,7 +108,10 @@
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             android:layout_marginTop="12dp"
-            android:layout_marginBottom="16dp"/>
+            android:layout_marginBottom="16dp"
+            tools:visibility="visible"
+            tools:listitem="@layout/row_tag_clickable"
+            tools:itemCount="1" />
 
         <ImageButton
             android:id="@+id/addToFavoritesButton"
@@ -126,7 +123,8 @@
             android:tint="@color/colorPrimary"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent" />
+            app:layout_constraintEnd_toEndOf="parent"
+            tools:src="@sample/sessions.json/data/starResource" />
 
     </android.support.constraint.ConstraintLayout>
 

--- a/app/src/main/res/layout/row_speaker.xml
+++ b/app/src/main/res/layout/row_speaker.xml
@@ -18,9 +18,9 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-
         android:layout_width="16dp"
-        android:layout_height="wrap_content" />
+        android:layout_height="wrap_content"
+        tools:text=" " />
 
     <ImageView
         android:id="@+id/avatarImageView"
@@ -46,7 +46,8 @@
         android:layout_marginStart="16dp"
         app:layout_constraintEnd_toStartOf="@+id/socialLinearLayout"
         app:layout_constraintTop_toTopOf="@+id/avatarImageView"
-        app:layout_constraintStart_toEndOf="@+id/avatarImageView" />
+        app:layout_constraintStart_toEndOf="@+id/avatarImageView"
+        tools:text="@tools:sample/full_names" />
 
     <TextView
         android:id="@+id/companyTextView"
@@ -55,7 +56,8 @@
         android:layout_height="wrap_content"
         android:layout_marginTop="2dp"
         app:layout_constraintTop_toBottomOf="@id/nameTextView"
-        app:layout_constraintStart_toStartOf="@id/nameTextView" />
+        app:layout_constraintStart_toStartOf="@id/nameTextView"
+        tools:text="@sample/sessions.json/data/company" />
 
     <LinearLayout
         android:id="@+id/socialLinearLayout"

--- a/app/src/main/res/layout/row_tag_clickable.xml
+++ b/app/src/main/res/layout/row_tag_clickable.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <TextView
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/tagTextView"
     android:background="@drawable/selector_background_tag_android"
     android:layout_marginEnd="8dp"
@@ -13,4 +14,5 @@
     android:layout_width="wrap_content"
     android:foreground="?android:attr/selectableItemBackground"
     android:clickable="true"
-    android:layout_height="24dp" />
+    android:layout_height="24dp"
+    tools:text="@sample/sessions.json/data/tag" />


### PR DESCRIPTION
Adding sample data to the layout files makes it easier to at a glance preview how the view/screen is going to look when run with actual data. Sample data is added using `tools` attributes and are stripped away from the code when it's being built for release.

Here's an example of what changed:

![before_after](https://user-images.githubusercontent.com/386122/47654754-d11bd780-db8b-11e8-90d1-a7e216730753.png)