### PR TITLE
Normalize filled/empty favorites star usage

### DIFF
--- a/app/src/main/java/rocks/mobileera/mobileera/adapters/viewHolders/SessionViewHolder.kt
+++ b/app/src/main/java/rocks/mobileera/mobileera/adapters/viewHolders/SessionViewHolder.kt
@@ -20,6 +20,7 @@ import rocks.mobileera.mobileera.utils.CircleTransform
 import rocks.mobileera.mobileera.utils.Preferences.Companion.domain
 import android.support.v7.widget.DividerItemDecoration
 import rocks.mobileera.mobileera.adapters.interfaces.AddToFavoritesCallback
+import rocks.mobileera.mobileera.utils.favoriteIconResForSession
 
 class SessionViewHolder(val view: View,  private val tagsListener: TagCallback?, private val addToFavoritesListener: AddToFavoritesCallback?) : RecyclerView.ViewHolder(view) {
     val titleTextView: TextView = view.titleTextView
@@ -38,7 +39,7 @@ class SessionViewHolder(val view: View,  private val tagsListener: TagCallback?,
     init {
         onAddToFavoritesListener = View.OnClickListener { v ->
             addToFavoritesListener?.onAddToFavoritesClick(session)
-            addToFavorites.setImageResource( if (session?.isFavorite(v.context.applicationContext) == true) R.drawable.star_filled else R.drawable.star_empty )
+            addToFavorites.setImageResource(favoriteIconResForSession(session, v.context.applicationContext))
         }
     }
 
@@ -122,7 +123,7 @@ class SessionViewHolder(val view: View,  private val tagsListener: TagCallback?,
         addToFavorites.setOnClickListener(onAddToFavoritesListener)
 
         addToFavorites.visibility = (if (session.isSystemAnnounce()) View.GONE else View.VISIBLE)
-        addToFavorites.setImageResource( if (session.isFavorite(context)) R.drawable.star_filled else R.drawable.star_empty )
+        addToFavorites.setImageResource(favoriteIconResForSession(session, context))
 
         addToFavorites.setOnClickListener(onAddToFavoritesListener)
     }

--- a/app/src/main/java/rocks/mobileera/mobileera/fragments/SessionFragment.kt
+++ b/app/src/main/java/rocks/mobileera/mobileera/fragments/SessionFragment.kt
@@ -23,6 +23,7 @@ import com.google.android.flexbox.FlexboxLayoutManager
 import com.google.android.flexbox.JustifyContent
 import rocks.mobileera.mobileera.adapters.TagsAdapter
 import rocks.mobileera.mobileera.adapters.interfaces.SpeakerCallback
+import rocks.mobileera.mobileera.utils.favoriteIconResForSession
 import java.text.SimpleDateFormat
 import java.util.*
 
@@ -83,7 +84,7 @@ class SessionFragment : Fragment() {
     override fun onPrepareOptionsMenu(menu: Menu?) {
         super.onPrepareOptionsMenu(menu)
         activity?.applicationContext?.let {
-            menu?.findItem(R.id.btnAddToFavorites)?.setIcon( if (session?.isFavorite(it) == false) R.drawable.star_filled else R.drawable.star_empty)
+            menu?.findItem(R.id.btnAddToFavorites)?.setIcon(favoriteIconResForSession(session, it))
         }
     }
 
@@ -92,7 +93,7 @@ class SessionFragment : Fragment() {
             R.id.btnAddToFavorites -> {
                 activity?.applicationContext?.let {
                     session?.toggleFavorites(it)
-                    item.setIcon(if (session?.isFavorite(it) == false) R.drawable.star_filled else R.drawable.star_empty)
+                    item.setIcon(favoriteIconResForSession(session, it))
                 }
             }
 

--- a/app/src/main/java/rocks/mobileera/mobileera/utils/Favorites.kt
+++ b/app/src/main/java/rocks/mobileera/mobileera/utils/Favorites.kt
@@ -1,0 +1,13 @@
+package rocks.mobileera.mobileera.utils
+
+import android.content.Context
+import android.support.annotation.DrawableRes
+import rocks.mobileera.mobileera.R
+import rocks.mobileera.mobileera.model.Session
+
+@DrawableRes
+fun favoriteIconResForSession(session: Session?, context: Context): Int {
+    if (session == null) return R.drawable.star_empty
+
+    return if (session.isFavorite(context)) R.drawable.star_filled else R.drawable.star_empty
+}


### PR DESCRIPTION
Always use a filled star in sessions that are favorited, and the empty star for those that are not.

Before this, the “filled” icon is used for sessions that are favorited in the list, but the empty star is used for favorites when viewing the details page of the session. Normalized the usage by extracting the icon lookup into its own helper.