### PR TITLE
Make callbacks local lambas

### DIFF
--- a/app/src/main/java/rocks/mobileera/mobileera/MainActivity.kt
+++ b/app/src/main/java/rocks/mobileera/mobileera/MainActivity.kt
@@ -8,10 +8,8 @@ import androidx.navigation.fragment.NavHostFragment.findNavController
 import androidx.navigation.ui.NavigationUI
 import androidx.navigation.ui.NavigationUI.setupActionBarWithNavController
 import kotlinx.android.synthetic.main.activity_main.*
-import rocks.mobileera.mobileera.adapters.interfaces.AddToFavoritesCallback
-import rocks.mobileera.mobileera.model.Session
 
-class MainActivity : AppCompatActivity(), AddToFavoritesCallback {
+class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -28,9 +26,4 @@ class MainActivity : AppCompatActivity(), AddToFavoritesCallback {
 
     override fun onSupportNavigateUp() = findNavController(hostFragment).navigateUp()
 
-    override fun onAddToFavoritesClick(session: Session?) {
-        applicationContext?.let {context ->
-            session?.toggleFavorites(context)
-        }
-    }
 }

--- a/app/src/main/java/rocks/mobileera/mobileera/MainActivity.kt
+++ b/app/src/main/java/rocks/mobileera/mobileera/MainActivity.kt
@@ -3,19 +3,17 @@ package rocks.mobileera.mobileera
 import android.os.Bundle
 import android.support.design.widget.BottomNavigationView
 import android.support.v7.app.AppCompatActivity
-import androidx.navigation.ui.NavigationUI
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.fragment.NavHostFragment.findNavController
+import androidx.navigation.ui.NavigationUI
 import androidx.navigation.ui.NavigationUI.setupActionBarWithNavController
+import kotlinx.android.synthetic.main.activity_main.*
 import rocks.mobileera.mobileera.adapters.interfaces.AddToFavoritesCallback
 import rocks.mobileera.mobileera.adapters.interfaces.SessionCallback
-import rocks.mobileera.mobileera.adapters.interfaces.SpeakerCallback
-import kotlinx.android.synthetic.main.activity_main.*
 import rocks.mobileera.mobileera.fragments.SessionFragment
 import rocks.mobileera.mobileera.model.Session
-import rocks.mobileera.mobileera.model.Speaker
 
-class MainActivity : AppCompatActivity(), SpeakerCallback, SessionCallback, AddToFavoritesCallback {
+class MainActivity : AppCompatActivity(), SessionCallback, AddToFavoritesCallback {
 
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -33,13 +31,6 @@ class MainActivity : AppCompatActivity(), SpeakerCallback, SessionCallback, AddT
 
     override fun onSupportNavigateUp() =
             findNavController(hostFragment).navigateUp()
-
-    override fun onSpeakerClick(speaker: Speaker?, action: Int) {
-        speaker?.let { value ->
-            val bundle = SpeakerActivity.createBundle(value)
-            NavHostFragment.findNavController(hostFragment).navigate(action, bundle)
-        }
-    }
 
     override fun onSessionClick(session: Session?) {
         session?.let { value ->

--- a/app/src/main/java/rocks/mobileera/mobileera/MainActivity.kt
+++ b/app/src/main/java/rocks/mobileera/mobileera/MainActivity.kt
@@ -9,12 +9,9 @@ import androidx.navigation.ui.NavigationUI
 import androidx.navigation.ui.NavigationUI.setupActionBarWithNavController
 import kotlinx.android.synthetic.main.activity_main.*
 import rocks.mobileera.mobileera.adapters.interfaces.AddToFavoritesCallback
-import rocks.mobileera.mobileera.adapters.interfaces.SessionCallback
-import rocks.mobileera.mobileera.fragments.SessionFragment
 import rocks.mobileera.mobileera.model.Session
 
-class MainActivity : AppCompatActivity(), SessionCallback, AddToFavoritesCallback {
-
+class MainActivity : AppCompatActivity(), AddToFavoritesCallback {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -29,15 +26,7 @@ class MainActivity : AppCompatActivity(), SessionCallback, AddToFavoritesCallbac
         setupActionBarWithNavController(this, findNavController(hostFragment))
     }
 
-    override fun onSupportNavigateUp() =
-            findNavController(hostFragment).navigateUp()
-
-    override fun onSessionClick(session: Session?) {
-        session?.let { value ->
-            val bundle = SessionFragment.createBundle(value)
-            NavHostFragment.findNavController(hostFragment).navigate(R.id.action_navigation_schedule_to_sessionFragment, bundle)
-        }
-    }
+    override fun onSupportNavigateUp() = findNavController(hostFragment).navigateUp()
 
     override fun onAddToFavoritesClick(session: Session?) {
         applicationContext?.let {context ->

--- a/app/src/main/java/rocks/mobileera/mobileera/adapters/DayAdapter.kt
+++ b/app/src/main/java/rocks/mobileera/mobileera/adapters/DayAdapter.kt
@@ -7,26 +7,24 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
 import kotlinx.android.synthetic.main.row_header_timeslot.view.*
-import kotlinx.android.synthetic.main.row_session.view.*
 import rocks.mobileera.mobileera.R
 import rocks.mobileera.mobileera.adapters.interfaces.AddToFavoritesCallback
-import rocks.mobileera.mobileera.adapters.interfaces.SessionCallback
+import rocks.mobileera.mobileera.adapters.interfaces.OnSessionClickedListener
 import rocks.mobileera.mobileera.adapters.interfaces.TagCallback
 import rocks.mobileera.mobileera.adapters.viewHolders.SessionViewHolder
 import rocks.mobileera.mobileera.model.Day
 import rocks.mobileera.mobileera.model.Legend
-
-import rocks.mobileera.mobileera.utils.Preferences
 import rocks.mobileera.mobileera.model.Session
 import rocks.mobileera.mobileera.model.Timeslot
+import rocks.mobileera.mobileera.utils.Preferences
 
 class DayAdapter(
-        private val context: Context?,
-        day: Day?,
-        private val sessionListener: SessionCallback?,
-        private val addToFavoritesListener: AddToFavoritesCallback?,
-        private val tagsListener: TagCallback?)
-    : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
+    private val context: Context?,
+    day: Day?,
+    private val onSessionClicked: OnSessionClickedListener,
+    private val addToFavoritesListener: AddToFavoritesCallback?,
+    private val tagsListener: TagCallback?
+) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
 
     private val onSessionClickListener: View.OnClickListener
     private val VIEW_HOLDER_TYPE_HEADER = 0
@@ -47,10 +45,9 @@ class DayAdapter(
             position?.let {
                 val session = data.getOrNull(position)
                 if (session is Session) {
-                   sessionListener?.onSessionClick(session)
+                   onSessionClicked(session)
                 }
             }
-
         }
     }
 

--- a/app/src/main/java/rocks/mobileera/mobileera/adapters/DayAdapter.kt
+++ b/app/src/main/java/rocks/mobileera/mobileera/adapters/DayAdapter.kt
@@ -8,7 +8,7 @@ import android.view.ViewGroup
 import android.widget.TextView
 import kotlinx.android.synthetic.main.row_header_timeslot.view.*
 import rocks.mobileera.mobileera.R
-import rocks.mobileera.mobileera.adapters.interfaces.AddToFavoritesCallback
+import rocks.mobileera.mobileera.adapters.interfaces.OnAddToFavoritesClickedListener
 import rocks.mobileera.mobileera.adapters.interfaces.OnSessionClickedListener
 import rocks.mobileera.mobileera.adapters.interfaces.TagCallback
 import rocks.mobileera.mobileera.adapters.viewHolders.SessionViewHolder
@@ -22,7 +22,7 @@ class DayAdapter(
     private val context: Context?,
     day: Day?,
     private val onSessionClicked: OnSessionClickedListener,
-    private val addToFavoritesListener: AddToFavoritesCallback?,
+    private val onAddToFavoritesClicked: OnAddToFavoritesClickedListener,
     private val tagsListener: TagCallback?
 ) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
 
@@ -58,7 +58,7 @@ class DayAdapter(
         }
 
         if (viewType == VIEW_HOLDER_TYPE_SESSION) {
-            return SessionViewHolder(LayoutInflater.from(parent.context).inflate(R.layout.row_session, parent, false), tagsListener, addToFavoritesListener)
+            return SessionViewHolder(LayoutInflater.from(parent.context).inflate(R.layout.row_session, parent, false), tagsListener, onAddToFavoritesClicked)
         }
 
         return LegendViewHolder(LayoutInflater.from(parent.context).inflate(R.layout.row_legend, parent, false))

--- a/app/src/main/java/rocks/mobileera/mobileera/adapters/DayAdapter.kt
+++ b/app/src/main/java/rocks/mobileera/mobileera/adapters/DayAdapter.kt
@@ -10,7 +10,7 @@ import kotlinx.android.synthetic.main.row_header_timeslot.view.*
 import rocks.mobileera.mobileera.R
 import rocks.mobileera.mobileera.adapters.interfaces.OnAddToFavoritesClickedListener
 import rocks.mobileera.mobileera.adapters.interfaces.OnSessionClickedListener
-import rocks.mobileera.mobileera.adapters.interfaces.TagCallback
+import rocks.mobileera.mobileera.adapters.interfaces.OnTagClickedListener
 import rocks.mobileera.mobileera.adapters.viewHolders.SessionViewHolder
 import rocks.mobileera.mobileera.model.Day
 import rocks.mobileera.mobileera.model.Legend
@@ -23,7 +23,7 @@ class DayAdapter(
     day: Day?,
     private val onSessionClicked: OnSessionClickedListener,
     private val onAddToFavoritesClicked: OnAddToFavoritesClickedListener,
-    private val tagsListener: TagCallback?
+    private val onTagClicked: OnTagClickedListener
 ) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
 
     private val onSessionClickListener: View.OnClickListener
@@ -52,16 +52,25 @@ class DayAdapter(
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder  {
+        val layoutInflater = LayoutInflater.from(parent.context)
 
-        if (viewType == VIEW_HOLDER_TYPE_HEADER) {
-            return HeaderViewHolder(LayoutInflater.from(parent.context).inflate(R.layout.row_header_timeslot, parent, false))
+        return when (viewType) {
+            VIEW_HOLDER_TYPE_HEADER -> {
+                val itemView = layoutInflater.inflate(R.layout.row_header_timeslot, parent, false)
+
+                HeaderViewHolder(itemView)
+            }
+            VIEW_HOLDER_TYPE_SESSION -> {
+                val itemView = layoutInflater.inflate(R.layout.row_session, parent, false)
+
+                SessionViewHolder(itemView, onTagClicked, onAddToFavoritesClicked)
+            }
+            else -> {
+                val itemView = layoutInflater.inflate(R.layout.row_legend, parent, false)
+
+                LegendViewHolder(itemView)
+            }
         }
-
-        if (viewType == VIEW_HOLDER_TYPE_SESSION) {
-            return SessionViewHolder(LayoutInflater.from(parent.context).inflate(R.layout.row_session, parent, false), tagsListener, onAddToFavoritesClicked)
-        }
-
-        return LegendViewHolder(LayoutInflater.from(parent.context).inflate(R.layout.row_legend, parent, false))
     }
 
     override fun getItemViewType(position: Int): Int {

--- a/app/src/main/java/rocks/mobileera/mobileera/adapters/SpeakersAdapter.kt
+++ b/app/src/main/java/rocks/mobileera/mobileera/adapters/SpeakersAdapter.kt
@@ -11,8 +11,8 @@ import rocks.mobileera.mobileera.model.Speaker
 
 class SpeakersAdapter(
         speakersList: List<Speaker>?,
-        private val listener: SpeakerCallback?)
-    : RecyclerView.Adapter<SpeakerViewHolder>() {
+        private val onSpeakerClicked: SpeakerCallback
+) : RecyclerView.Adapter<SpeakerViewHolder>() {
 
     var speakers = speakersList
         set(value) {
@@ -27,7 +27,7 @@ class SpeakersAdapter(
             val position = v.tag as? Int
             position?.let {
                 val speaker = speakers?.getOrNull(position)
-                listener?.onSpeakerClick(speaker, R.id.action_navigation_speakers_to_speakerActivity)
+                onSpeakerClicked(speaker)
             }
         }
     }

--- a/app/src/main/java/rocks/mobileera/mobileera/adapters/TagsAdapter.kt
+++ b/app/src/main/java/rocks/mobileera/mobileera/adapters/TagsAdapter.kt
@@ -7,13 +7,13 @@ import android.view.ViewGroup
 import android.widget.TextView
 import kotlinx.android.synthetic.main.row_tag_clickable.view.*
 import rocks.mobileera.mobileera.R
-import rocks.mobileera.mobileera.adapters.interfaces.TagCallback
+import rocks.mobileera.mobileera.adapters.interfaces.OnTagClickedListener
 import rocks.mobileera.mobileera.model.Tag
 
 class TagsAdapter (
-        private val tags: List<String>,
-        private val listener: TagCallback?)
-    : RecyclerView.Adapter<TagsAdapter.ViewHolder>() {
+    private val tags: List<String>,
+    private val onTagClicked: OnTagClickedListener
+) : RecyclerView.Adapter<TagsAdapter.ViewHolder>() {
 
     private val onClickListener: View.OnClickListener
 
@@ -22,7 +22,7 @@ class TagsAdapter (
             val position = v.tag
             if (position is Int) {
                 tags.getOrNull(position)?.let {tag ->
-                    listener?.onTagClick(tag)
+                    onTagClicked(tag)
                 }
             }
         }

--- a/app/src/main/java/rocks/mobileera/mobileera/adapters/interfaces/AddToFavoritesCallback.kt
+++ b/app/src/main/java/rocks/mobileera/mobileera/adapters/interfaces/AddToFavoritesCallback.kt
@@ -2,6 +2,4 @@ package rocks.mobileera.mobileera.adapters.interfaces
 
 import rocks.mobileera.mobileera.model.Session
 
-interface AddToFavoritesCallback {
-    fun onAddToFavoritesClick(session: Session?)
-}
+typealias OnAddToFavoritesClickedListener = (session: Session?) -> Unit

--- a/app/src/main/java/rocks/mobileera/mobileera/adapters/interfaces/SessionCallback.kt
+++ b/app/src/main/java/rocks/mobileera/mobileera/adapters/interfaces/SessionCallback.kt
@@ -2,6 +2,4 @@ package rocks.mobileera.mobileera.adapters.interfaces
 
 import rocks.mobileera.mobileera.model.Session
 
-interface SessionCallback {
-    fun onSessionClick(session: Session?)
-}
+typealias OnSessionClickedListener = (session: Session?) -> Unit

--- a/app/src/main/java/rocks/mobileera/mobileera/adapters/interfaces/SpeakerCallback.kt
+++ b/app/src/main/java/rocks/mobileera/mobileera/adapters/interfaces/SpeakerCallback.kt
@@ -2,6 +2,4 @@ package rocks.mobileera.mobileera.adapters.interfaces
 
 import rocks.mobileera.mobileera.model.Speaker
 
-interface SpeakerCallback {
-    fun onSpeakerClick(speaker: Speaker?, action: Int)
-}
+typealias SpeakerCallback = (speaker: Speaker?) -> Unit

--- a/app/src/main/java/rocks/mobileera/mobileera/adapters/interfaces/TagCallback.kt
+++ b/app/src/main/java/rocks/mobileera/mobileera/adapters/interfaces/TagCallback.kt
@@ -1,5 +1,3 @@
 package rocks.mobileera.mobileera.adapters.interfaces
 
-interface TagCallback {
-    fun onTagClick(tag: String)
-}
+typealias OnTagClickedListener = (tag: String) -> Unit

--- a/app/src/main/java/rocks/mobileera/mobileera/adapters/viewHolders/SessionViewHolder.kt
+++ b/app/src/main/java/rocks/mobileera/mobileera/adapters/viewHolders/SessionViewHolder.kt
@@ -19,10 +19,14 @@ import rocks.mobileera.mobileera.model.Session
 import rocks.mobileera.mobileera.utils.CircleTransform
 import rocks.mobileera.mobileera.utils.Preferences.Companion.domain
 import android.support.v7.widget.DividerItemDecoration
-import rocks.mobileera.mobileera.adapters.interfaces.AddToFavoritesCallback
+import rocks.mobileera.mobileera.adapters.interfaces.OnAddToFavoritesClickedListener
 import rocks.mobileera.mobileera.utils.favoriteIconResForSession
 
-class SessionViewHolder(val view: View,  private val tagsListener: TagCallback?, private val addToFavoritesListener: AddToFavoritesCallback?) : RecyclerView.ViewHolder(view) {
+class SessionViewHolder(
+    val view: View,
+    private val tagsListener: TagCallback?,
+    private val onAddToFavoritesClicked: OnAddToFavoritesClickedListener
+) : RecyclerView.ViewHolder(view) {
     val titleTextView: TextView = view.titleTextView
     val nameTextView: TextView = view.nameTextView
     val avatarImageView: ImageView = view.avatarImageView
@@ -38,7 +42,7 @@ class SessionViewHolder(val view: View,  private val tagsListener: TagCallback?,
 
     init {
         onAddToFavoritesListener = View.OnClickListener { v ->
-            addToFavoritesListener?.onAddToFavoritesClick(session)
+            onAddToFavoritesClicked(session)
             addToFavorites.setImageResource(favoriteIconResForSession(session, v.context.applicationContext))
         }
     }

--- a/app/src/main/java/rocks/mobileera/mobileera/adapters/viewHolders/SessionViewHolder.kt
+++ b/app/src/main/java/rocks/mobileera/mobileera/adapters/viewHolders/SessionViewHolder.kt
@@ -14,7 +14,7 @@ import com.squareup.picasso.Picasso
 import kotlinx.android.synthetic.main.row_session.view.*
 import rocks.mobileera.mobileera.R
 import rocks.mobileera.mobileera.adapters.TagsAdapter
-import rocks.mobileera.mobileera.adapters.interfaces.TagCallback
+import rocks.mobileera.mobileera.adapters.interfaces.OnTagClickedListener
 import rocks.mobileera.mobileera.model.Session
 import rocks.mobileera.mobileera.utils.CircleTransform
 import rocks.mobileera.mobileera.utils.Preferences.Companion.domain
@@ -24,7 +24,7 @@ import rocks.mobileera.mobileera.utils.favoriteIconResForSession
 
 class SessionViewHolder(
     val view: View,
-    private val tagsListener: TagCallback?,
+    private val onTagClicked: OnTagClickedListener,
     private val onAddToFavoritesClicked: OnAddToFavoritesClickedListener
 ) : RecyclerView.ViewHolder(view) {
     val titleTextView: TextView = view.titleTextView
@@ -84,7 +84,7 @@ class SessionViewHolder(
             layoutManager.flexDirection = FlexDirection.ROW_REVERSE
             layoutManager.justifyContent = JustifyContent.FLEX_END
             tagsRecyclerView.layoutManager = layoutManager
-            tagsRecyclerView.adapter = TagsAdapter(tags, tagsListener)
+            tagsRecyclerView.adapter = TagsAdapter(tags, onTagClicked)
 
             val dividerItemDecoration = DividerItemDecoration(context,
                     RecyclerView.VERTICAL)

--- a/app/src/main/java/rocks/mobileera/mobileera/fragments/DayFragment.kt
+++ b/app/src/main/java/rocks/mobileera/mobileera/fragments/DayFragment.kt
@@ -10,21 +10,30 @@ import android.support.v7.widget.RecyclerView
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.navigation.fragment.NavHostFragment
 import rocks.mobileera.mobileera.R
 import rocks.mobileera.mobileera.adapters.DayAdapter
 import rocks.mobileera.mobileera.adapters.interfaces.AddToFavoritesCallback
-import rocks.mobileera.mobileera.adapters.interfaces.SessionCallback
+import rocks.mobileera.mobileera.adapters.interfaces.OnSessionClickedListener
 import rocks.mobileera.mobileera.adapters.interfaces.TagCallback
 import rocks.mobileera.mobileera.model.Day
 import rocks.mobileera.mobileera.viewModels.ScheduleViewModel
-
 
 class DayFragment: Fragment() {
 
     private val ARGS_DAY_INDEX = "ARGS_DAY_INDEX"
     private val ARGS_TITLE = "ARGS_TITLE"
 
-    private var sessionListener: SessionCallback? = null
+    private var onSessionClicked: OnSessionClickedListener = { session ->
+    private val onSessionClicked: OnSessionClickedListener = { session ->
+        session?.let { value ->
+            val navController = NavHostFragment.findNavController(this)
+            val bundle = SessionFragment.createBundle(value)
+
+            navController.navigate(R.id.action_navigation_schedule_to_sessionFragment, bundle)
+        }
+    }
+
     private var tagListener: TagCallback? = null
     private var addToFavoritesListener: AddToFavoritesCallback? = null
 
@@ -72,24 +81,19 @@ class DayFragment: Fragment() {
         if (context is TagCallback) {
             tagListener = context
         }
-
-        if (context is SessionCallback) {
-            sessionListener = context
-        }
     }
 
     override fun onDetach() {
         super.onDetach()
         addToFavoritesListener = null
         tagListener = null
-        sessionListener = null
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         val view = inflater.inflate(R.layout.fragment_day, container, false)
 
         parentFragment?.let {
-            dayAdapter = DayAdapter(activity?.applicationContext, day, sessionListener, addToFavoritesListener, tagListener)
+            dayAdapter = DayAdapter(activity?.applicationContext, day, onSessionClicked, addToFavoritesListener, tagListener)
 
             val viewModel = ViewModelProviders.of(it).get(ScheduleViewModel::class.java)
             viewModel.getDays()?.observe(this, Observer<List<Day>> { days ->

--- a/app/src/main/java/rocks/mobileera/mobileera/fragments/DayFragment.kt
+++ b/app/src/main/java/rocks/mobileera/mobileera/fragments/DayFragment.kt
@@ -2,7 +2,6 @@ package rocks.mobileera.mobileera.fragments
 
 import android.arch.lifecycle.Observer
 import android.arch.lifecycle.ViewModelProviders
-import android.content.Context
 import android.os.Bundle
 import android.support.v4.app.Fragment
 import android.support.v7.widget.LinearLayoutManager
@@ -15,7 +14,6 @@ import rocks.mobileera.mobileera.R
 import rocks.mobileera.mobileera.adapters.DayAdapter
 import rocks.mobileera.mobileera.adapters.interfaces.OnAddToFavoritesClickedListener
 import rocks.mobileera.mobileera.adapters.interfaces.OnSessionClickedListener
-import rocks.mobileera.mobileera.adapters.interfaces.TagCallback
 import rocks.mobileera.mobileera.model.Day
 import rocks.mobileera.mobileera.viewModels.ScheduleViewModel
 
@@ -38,8 +36,6 @@ class DayFragment: Fragment() {
             navController.navigate(R.id.action_navigation_schedule_to_sessionFragment, bundle)
         }
     }
-
-    private var tagListener: TagCallback? = null
 
     private var title: CharSequence? = ""
     private var dayIndex: Int = 0
@@ -76,18 +72,6 @@ class DayFragment: Fragment() {
         return ""
     }
 
-    override fun onAttach(context: Context) {
-        super.onAttach(context)
-        if (context is TagCallback) {
-            tagListener = context
-        }
-    }
-
-    override fun onDetach() {
-        super.onDetach()
-        tagListener = null
-    }
-
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         val view = inflater.inflate(R.layout.fragment_day, container, false)
 
@@ -97,7 +81,7 @@ class DayFragment: Fragment() {
                 day = day,
                 onSessionClicked = onSessionClicked,
                 onAddToFavoritesClicked = onAddToFavoritesClicked,
-                tagsListener = tagListener
+                onTagClicked = { }
             )
 
             val viewModel = ViewModelProviders.of(it).get(ScheduleViewModel::class.java)

--- a/app/src/main/java/rocks/mobileera/mobileera/fragments/DayFragment.kt
+++ b/app/src/main/java/rocks/mobileera/mobileera/fragments/DayFragment.kt
@@ -13,7 +13,7 @@ import android.view.ViewGroup
 import androidx.navigation.fragment.NavHostFragment
 import rocks.mobileera.mobileera.R
 import rocks.mobileera.mobileera.adapters.DayAdapter
-import rocks.mobileera.mobileera.adapters.interfaces.AddToFavoritesCallback
+import rocks.mobileera.mobileera.adapters.interfaces.OnAddToFavoritesClickedListener
 import rocks.mobileera.mobileera.adapters.interfaces.OnSessionClickedListener
 import rocks.mobileera.mobileera.adapters.interfaces.TagCallback
 import rocks.mobileera.mobileera.model.Day
@@ -24,7 +24,12 @@ class DayFragment: Fragment() {
     private val ARGS_DAY_INDEX = "ARGS_DAY_INDEX"
     private val ARGS_TITLE = "ARGS_TITLE"
 
-    private var onSessionClicked: OnSessionClickedListener = { session ->
+    private val onAddToFavoritesClicked: OnAddToFavoritesClickedListener = { session ->
+        context?.let { context ->
+            session?.toggleFavorites(context)
+        }
+    }
+
     private val onSessionClicked: OnSessionClickedListener = { session ->
         session?.let { value ->
             val navController = NavHostFragment.findNavController(this)
@@ -35,7 +40,6 @@ class DayFragment: Fragment() {
     }
 
     private var tagListener: TagCallback? = null
-    private var addToFavoritesListener: AddToFavoritesCallback? = null
 
     private var title: CharSequence? = ""
     private var dayIndex: Int = 0
@@ -74,10 +78,6 @@ class DayFragment: Fragment() {
 
     override fun onAttach(context: Context) {
         super.onAttach(context)
-        if (context is AddToFavoritesCallback) {
-            addToFavoritesListener = context
-        }
-
         if (context is TagCallback) {
             tagListener = context
         }
@@ -85,7 +85,6 @@ class DayFragment: Fragment() {
 
     override fun onDetach() {
         super.onDetach()
-        addToFavoritesListener = null
         tagListener = null
     }
 
@@ -93,7 +92,13 @@ class DayFragment: Fragment() {
         val view = inflater.inflate(R.layout.fragment_day, container, false)
 
         parentFragment?.let {
-            dayAdapter = DayAdapter(activity?.applicationContext, day, onSessionClicked, addToFavoritesListener, tagListener)
+            dayAdapter = DayAdapter(
+                context = activity?.applicationContext,
+                day = day,
+                onSessionClicked = onSessionClicked,
+                onAddToFavoritesClicked = onAddToFavoritesClicked,
+                tagsListener = tagListener
+            )
 
             val viewModel = ViewModelProviders.of(it).get(ScheduleViewModel::class.java)
             viewModel.getDays()?.observe(this, Observer<List<Day>> { days ->

--- a/app/src/main/java/rocks/mobileera/mobileera/fragments/SessionFragment.kt
+++ b/app/src/main/java/rocks/mobileera/mobileera/fragments/SessionFragment.kt
@@ -18,9 +18,11 @@ import android.provider.CalendarContract
 import android.support.v4.content.ContextCompat
 import android.support.v7.widget.DividerItemDecoration
 import android.support.v7.widget.RecyclerView
+import androidx.navigation.fragment.NavHostFragment
 import com.google.android.flexbox.FlexDirection
 import com.google.android.flexbox.FlexboxLayoutManager
 import com.google.android.flexbox.JustifyContent
+import rocks.mobileera.mobileera.SpeakerActivity
 import rocks.mobileera.mobileera.adapters.TagsAdapter
 import rocks.mobileera.mobileera.adapters.interfaces.SpeakerCallback
 import rocks.mobileera.mobileera.utils.favoriteIconResForSession
@@ -31,7 +33,15 @@ import java.util.*
 class SessionFragment : Fragment() {
 
     private val REQUEST_CODE_CALENDAR = 1
-    private var speakerListener: SpeakerCallback? = null
+
+    private var onSpeakerClicked: SpeakerCallback = { speaker ->
+        speaker?.let { value ->
+            val navController = NavHostFragment.findNavController(this)
+
+            val bundle = SpeakerActivity.createBundle(value)
+            navController.navigate(R.id.action_sessionFragment_to_speakerActivity, bundle)
+        }
+    }
 
     companion object {
 
@@ -52,7 +62,7 @@ class SessionFragment : Fragment() {
             val position = v.tag as? Int
             position?.let {
                 val speaker = session?.speakersList?.getOrNull(position)
-                speakerListener?.onSpeakerClick(speaker, R.id.action_sessionFragment_to_speakerActivity)
+                onSpeakerClicked(speaker)
             }
         }
     }
@@ -185,16 +195,4 @@ class SessionFragment : Fragment() {
         speaker2Layout.setOnClickListener(onClickListener)
     }
 
-
-    override fun onAttach(context: Context) {
-        super.onAttach(context)
-        if (context is SpeakerCallback) {
-            speakerListener = context
-        }
-    }
-
-    override fun onDetach() {
-        super.onDetach()
-        speakerListener = null
-    }
 }

--- a/app/src/main/java/rocks/mobileera/mobileera/fragments/SessionFragment.kt
+++ b/app/src/main/java/rocks/mobileera/mobileera/fragments/SessionFragment.kt
@@ -1,7 +1,5 @@
 package rocks.mobileera.mobileera.fragments
 
-
-import android.content.Context
 import android.os.Bundle
 import android.support.v4.app.Fragment
 import android.view.*
@@ -28,7 +26,6 @@ import rocks.mobileera.mobileera.adapters.interfaces.SpeakerCallback
 import rocks.mobileera.mobileera.utils.favoriteIconResForSession
 import java.text.SimpleDateFormat
 import java.util.*
-
 
 class SessionFragment : Fragment() {
 
@@ -160,7 +157,7 @@ class SessionFragment : Fragment() {
             layoutManager.flexDirection = FlexDirection.ROW_REVERSE
             layoutManager.justifyContent = JustifyContent.FLEX_END
             tagsRecyclerView.layoutManager = layoutManager
-            tagsRecyclerView.adapter = TagsAdapter(tags, null)
+            tagsRecyclerView.adapter = TagsAdapter(tags, onTagClicked = { })
 
             activity?.applicationContext?.resources?.getDrawable(R.drawable.divirer_tags_horizontal)?.let {
                 val dividerItemDecoration = DividerItemDecoration(context,

--- a/app/src/main/java/rocks/mobileera/mobileera/fragments/SpeakersFragment.kt
+++ b/app/src/main/java/rocks/mobileera/mobileera/fragments/SpeakersFragment.kt
@@ -2,14 +2,14 @@ package rocks.mobileera.mobileera.fragments
 
 import android.arch.lifecycle.Observer
 import android.arch.lifecycle.ViewModelProviders
-import android.content.Context
 import android.os.Bundle
-import android.support.v4.app.Fragment
 import android.support.v7.app.AppCompatActivity
 import android.support.v7.widget.LinearLayoutManager
 import android.view.*
+import androidx.navigation.fragment.NavHostFragment
 import kotlinx.android.synthetic.main.fragment_speakers.*
 import rocks.mobileera.mobileera.R
+import rocks.mobileera.mobileera.SpeakerActivity
 import rocks.mobileera.mobileera.adapters.SpeakersAdapter
 import rocks.mobileera.mobileera.adapters.interfaces.SpeakerCallback
 import rocks.mobileera.mobileera.model.Speaker
@@ -17,7 +17,6 @@ import rocks.mobileera.mobileera.viewModels.SpeakersViewModel
 
 class SpeakersFragment : BaseFragment() {
 
-    private var listener: SpeakerCallback? = null
     private lateinit var viewModel: SpeakersViewModel
     private lateinit var speakersAdapter: SpeakersAdapter
 
@@ -33,7 +32,17 @@ class SpeakersFragment : BaseFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        speakersAdapter = SpeakersAdapter(null, listener)
+
+        val speakerListener: SpeakerCallback = { speaker ->
+            speaker?.let { value ->
+                val navController = NavHostFragment.findNavController(this)
+
+                val bundle = SpeakerActivity.createBundle(value)
+                navController.navigate(R.id.action_navigation_speakers_to_speakerActivity, bundle)
+            }
+        }
+
+        speakersAdapter = SpeakersAdapter(null, speakerListener)
         speakersRecyclerView.layoutManager = LinearLayoutManager(context)
         speakersRecyclerView.adapter = speakersAdapter
         viewModel = ViewModelProviders.of(this).get(SpeakersViewModel::class.java)
@@ -45,19 +54,8 @@ class SpeakersFragment : BaseFragment() {
         (activity as? AppCompatActivity)?.supportActionBar?.setDisplayHomeAsUpEnabled(false)
     }
 
-    override fun onAttach(context: Context) {
-        super.onAttach(context)
-        if (context is SpeakerCallback) {
-            listener = context
-        }
-    }
-
-    override fun onDetach() {
-        super.onDetach()
-        listener = null
-    }
-
     override fun onCreateOptionsMenu(menu: Menu?, inflater: MenuInflater?) {
         inflater?.inflate(R.menu.menu_speakers, menu)
     }
+
 }


### PR DESCRIPTION
Decouple each fragment from the `MainActivity` by not having the activity implement interfaces that would make it the selection listener. Instead, have these listeners as local lambas in the fragments where they're used. It is possible to decouple like this because it's just as easy to find a `NavController` from a fragment or a `View` as it is to find it from the `AppCompatActivity` at the top.

This doesn't really fix any bugs, per se, but instead attempts to clean up the different classes' responsibilities a little bit. :slightly_smiling_face: 

It does also gets rid of some nullability as a side effect, though, which is always nice! :grinning: 